### PR TITLE
crawler err handle

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -55,7 +55,7 @@ var q = async.queue(function (task, callback) {
 
 function fetchHaixiuzu() {
   var ep = new eventproxy();
-  ep.fail(function (err) {
+  ep.on('error',function (err) {
     console.error(err);
   });
   superagent.get('https://database.duoshuo.com/api/threads/listPosts.json?thread_key=haixiuzu&page=1&limit=100')


### PR DESCRIPTION
我把ep.fail()改成ep.on('error')了

要不然q任务队列task执行之后，出现error的cb只能执行一次console.log(err)，因为fail内部执行了ep.unbind()